### PR TITLE
Support for "epoch" numbers in the `Version` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 Changelog
 =========
 
+3.1.0
+-----
+- Added support for *epoch* numbers in the `Version` type. These are numbers
+  like the `1:` in `1:2.3.4`. These are used in Arch Linux in rare cases where
+  packages change their versioning scheme, but need a reliable integer prefix
+  to establish ordering. The `Version` type has been given a new field,
+  `_vEpoch :: Maybe Int`, and a corresponding lens, `vEpoch`.
+
 3.0.2
 -----
-
 - Expose internal parsers so that they could be used in other parser programs
   that parse version numbers in larger files.
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: versions
-version: '3.0.2.1'
+version: '3.1.0'
 synopsis: Types and parsers for software version numbers.
 description: ! 'A library for parsing and comparing software version numbers.
 

--- a/package.yaml
+++ b/package.yaml
@@ -54,6 +54,8 @@ library:
   exposed-modules:
     - Data.Versions
 
+  other-modules: []
+
   dependencies:
     - megaparsec >=4 && <6
 

--- a/stack-710.yaml
+++ b/stack-710.yaml
@@ -1,4 +1,4 @@
-resolver: lts-6.33
+resolver: lts-6.35
 
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.15
+resolver: lts-8.17
 
 packages:
 - '.'

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -14,13 +14,11 @@ import Test.Tasty.HUnit
 -- | These don't need to parse as a SemVer.
 goodVers :: [Text]
 goodVers = [ "1", "1.2", "1.0rc0", "1.0rc1", "1.1rc1", "1.58.0-3",  "44.0.2403.157-1"
-           , "0.25-2",  "8.u51-1", "21-2", "7.1p1-1", "20150826-1"
+           , "0.25-2",  "8.u51-1", "21-2", "7.1p1-1", "20150826-1", "1:0.10.16-3"
            ]
 
 messes :: [Text]
-messes = [ "10.2+0.93+1-1", "003.03-3", "002.000-7", "1:0.10.16-3"
-         , "20.26.1_0-2"
-         ]
+messes = [ "10.2+0.93+1-1", "003.03-3", "002.000-7", "20.26.1_0-2" ]
 
 messComps :: [Text]
 messComps = [ "10.2+0.93+1-1", "10.2+0.93+1-2", "10.2+0.93+2-1"
@@ -91,8 +89,8 @@ suite = testGroup "Unit Tests"
       , testCase "1.2.3-1+1 is SemVer" $ check $ isSemVer <$> parseV "1.2.3-1+1"
       , testCase "1.2.3r1 is Version" $ check $ isVersion <$> parseV "1.2.3r1"
       , testCase "0.25-2 is Version" $ check $ isVersion <$> parseV "0.25-2"
+      , testCase "1:1.2.3-1 is Version" $ check $ isVersion <$> parseV "1:1.2.3-1"
       , testCase "1.2.3+1-1 is Mess" $ check $ isMess <$> parseV "1.2.3+1-1"
-      , testCase "1:1.2.3-1 is Mess" $ check $ isMess <$> parseV "1:1.2.3-1"
       , testCase "000.007-1 is Mess" $ check $ isMess <$> parseV "000.007-1"
       , testCase "20.26.1_0-2 is Mess" $ check $ isMess <$> parseV "20.26.1_0-2"
       ]
@@ -155,7 +153,7 @@ incPatch = (v1 & _Ideal . svPatch %~ (+ 1)) @?= v2
 -- | Nothing should happen.
 noInc :: Assertion
 noInc = (v & _Ideal . svPatch %~ (+ 1)) @?= v
-  where v = General $ Version [] []
+  where v = General $ Version Nothing [] []
 
 incFromT :: Assertion
 incFromT = ("1.2.3" & _Versioning . _Ideal . svPatch %~ (+ 1)) @?= "1.2.4"

--- a/versions.cabal
+++ b/versions.cabal
@@ -41,8 +41,6 @@ source-repository head
 library
   exposed-modules:
       Data.Versions
-  other-modules:
-      Paths_versions
   build-depends:
       base >=4.8 && <4.10
     , text >=1.2 && <1.3

--- a/versions.cabal
+++ b/versions.cabal
@@ -3,7 +3,7 @@
 -- see: https://github.com/sol/hpack
 
 name:           versions
-version:        3.0.2.1
+version:        3.1.0
 synopsis:       Types and parsers for software version numbers.
 description:    A library for parsing and comparing software version numbers.
                 We like to give version numbers to our software in a myriad of


### PR DESCRIPTION
These are prefixes like the `1:` in `1:2.3.4`. These are used in Arch Linux in rare cases where packages change their versioning scheme, but need a reliable integer prefix to establish ordering.