### PR TITLE
Whitespace Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+
+#### Changed
+
+- **Breaking:** `VChunk` now cannot be empty.
+- **Breaking:** A `Version` now guarantees `NonEmpty` chunks.
+- **Breaking:** A `Mess` now guarantees `NonEmpty` chunks, and is no longer a sum type.
+- Comparison of `Version` values is more memory efficient.
+
+#### Removed
+
+- **Breaking:** `Version` no longer has a `Monoid` instance.
+
+#### Fixed
+
+- `""` no longer parses in any way. [#32]
+- Version strings with trailing whitespace no longer parse via `versioning`. [#33]
+
+[#32]: https://github.com/fosskers/versions/issues/32
+[#33]: https://github.com/fosskers/versions/issues/33
+
 ## 3.5.4 (2020-05-12)
 
 #### Added

--- a/Data/Versions.hs
+++ b/Data/Versions.hs
@@ -793,10 +793,7 @@ mess = parse (mess' <* eof) "Mess"
 
 -- | Internal megaparsec parser of `mess`.
 mess' :: Parsec Void T.Text Mess
-mess' = L.lexeme space node
-
-node :: Parsec Void T.Text Mess
-node = Mess <$> tchunks <*> optional ((,) <$> sep <*> mess')
+mess' = Mess <$> tchunks <*> optional ((,) <$> sep <*> mess')
 
 tchunks :: Parsec Void T.Text (NonEmpty T.Text)
 tchunks = (T.pack <$> some (letterChar <|> digitChar)) `PC.sepBy1` char '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-16.12
+resolver: lts-16.17

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -2,12 +2,13 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Main where
+module Main ( main ) where
 
 import           Data.Char (chr)
 import           Data.Either (isLeft)
 import           Data.Foldable (fold)
 import           Data.List (groupBy)
+import qualified Data.List.NonEmpty as NEL
 import qualified Data.Text as T
 import           Data.Versions
 import           Data.Void (Void)
@@ -28,6 +29,9 @@ instance Arbitrary SemVer where
 chunks :: Gen [[VUnit]]
 chunks = resize 10 . listOf1 . fmap simplify . resize 10 $ listOf1 arbitrary
 
+chunksNE :: Gen (NEL.NonEmpty VChunk)
+chunksNE = undefined
+
 simplify :: [VUnit] -> [VUnit]
 simplify = map fold . groupBy f
   where f (Digits _) (Digits _) = True
@@ -45,13 +49,16 @@ instance Arbitrary Letter where
   arbitrary = Letter . chr <$> choose (97, 122)
 
 instance Arbitrary Version where
-  arbitrary = Version <$> arbitrary <*> chunks <*> chunks
+  arbitrary = Version <$> arbitrary <*> chunksNE <*> chunks
 
 -- | These don't need to parse as a SemVer.
 goodVers :: [T.Text]
 goodVers = [ "1", "1.2", "1.0rc0", "1.0rc1", "1.1rc1", "1.58.0-3",  "44.0.2403.157-1"
            , "0.25-2",  "8.u51-1", "21-2", "7.1p1-1", "20150826-1", "1:0.10.16-3"
            ]
+
+badVers :: [T.Text]
+badVers = ["", "1.2 "]
 
 messes :: [T.Text]
 messes = [ "10.2+0.93+1-1", "003.03-3", "002.000-7", "20.26.1_0-2" ]
@@ -63,7 +70,7 @@ messComps = [ "10.2+0.93+1-1", "10.2+0.93+1-2", "10.2+0.93+2-1"
 
 badSemVs :: [T.Text]
 badSemVs = [ "1", "1.2", "1.2.3+a1b2bc3.1-alpha.2", "a.b.c", "1.01.1"
-           , "1.2.3+a1b!2c3.1"
+           , "1.2.3+a1b!2c3.1", "", "1.2.3 "
            ]
 
 goodSemVs :: [T.Text]
@@ -123,6 +130,8 @@ suite = testGroup "Tests"
     , testGroup "(General) Versions"
       [ testGroup "Good Versions" $
         map (\s -> testCase (T.unpack s) $ isomorphV s) goodVers
+      , testGroup "Bad Versions (shouldn't parse)" $
+        map (\s -> testCase (T.unpack s) $ assertBool "A bad version parsed" $ isLeft $ version s) badVers
       , testGroup "Comparisons" $
         testCase "1.2-5 < 1.2.3-1" (comp version "1.2-5" "1.2.3-1") :
         testCase "1.0rc1 < 1.0" (comp version "1.0rc1" "1.0") :
@@ -173,13 +182,14 @@ suite = testGroup "Tests"
         , testCase "1.2-5 < 1.2.3-1"       $ comp versioning "1.2-5" "1.2.3-1"
         , testCase "1.6.0a+2014+m872b87e73dfb-1 < 1.6.0-1"
           $ comp versioning "1.6.0a+2014+m872b87e73dfb-1" "1.6.0-1"
+        -- , testCase "1.11.0.git.20200404-1 < 1.11.0+20200830-1"
+        --   $ comp versioning "1.11.0.git.20200404-1" "1.11.0+20200830-1"
         ]
       ]
     , testGroup "Lenses and Traversals"
       [ testCase "SemVer - Increment Patch" incPatch
       , testCase "SemVer - Increment Patch from Text" incFromT
       , testCase "SemVer - Get patches" patches
-      , testCase "Traverse `General` as `Ideal`" noInc
       ]
     , testGroup "Megaparsec Behaviour"
       [ testCase "manyTill" $ parse nameGrab "manyTill" "linux-firmware-3.2.14-1-x86_64.pkg.tar.xz" @?= Right "linux-firmware"
@@ -228,11 +238,6 @@ incPatch :: Assertion
 incPatch = (v1 & patch %~ (+ 1)) @?= v2
   where v1 = Ideal $ SemVer 1 2 3 [] []
         v2 = Ideal $ SemVer 1 2 4 [] []
-
--- | Nothing should happen.
-noInc :: Assertion
-noInc = (v & patch %~ (+ 1)) @?= v
-  where v = General $ Version Nothing [] []
 
 incFromT :: Assertion
 incFromT = (("1.2.3" :: T.Text) & patch %~ (+ 1)) @?= "1.2.4"

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -175,6 +175,8 @@ suite = testGroup "Tests"
         , testCase "000.007-1 is Mess" $ check $ isMess <$> versioning "000.007-1"
         , testCase "20.26.1_0-2 is Mess" $ check $ isMess <$> versioning "20.26.1_0-2"
         ]
+      , testGroup "Bad Versions" $
+        map (\s -> testCase (T.unpack s) $ assertBool "A bad version parsed" $ isLeft $ versioning s) badVers
       , testGroup "Isomorphisms" $
         map (\s -> testCase (T.unpack s) $ isomorph s) $ goodSemVs ++ goodVers ++ messes
       , testGroup "Comparisons"

--- a/versions.cabal
+++ b/versions.cabal
@@ -48,6 +48,7 @@ library
   build-depends:
     , deepseq   >=1.4
     , hashable  >=1.2
+    , parser-combinators >= 1.0
 
 test-suite versions-test
   import:         commons


### PR DESCRIPTION
This PR fixes a few edge cases involving whitespace in version strings. It also introduces a few breaking changes in the core data types themselves to support the fix.