### PR TITLE
Bump base bound.

### DIFF
--- a/versions.cabal
+++ b/versions.cabal
@@ -40,7 +40,7 @@ common commons
     -Wincomplete-uni-patterns
 
   build-depends:
-    , base        >=4.10 && <4.18
+    , base        >=4.10 && <4.19
     , megaparsec  >=7
     , text        ^>=1.2 || ^>= 2.0
 


### PR DESCRIPTION
This allows compilation with GHC 9.6.