### PR TITLE
Back Compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,6 @@ jobs:
             "lts-18.28",
             "lts-16.31",
             "lts-14.27",
-            "lts-12.26",
-            "lts-11.22",
-            "lts-9.21",
           ]
         include:
           - resolver: "lts-20.20"
@@ -47,21 +44,6 @@ jobs:
           - resolver: "lts-14.27"
             os: ubuntu-latest
             ghc: "8.6.5"
-            cabal: latest
-            stack: latest
-          - resolver: "lts-12.26"
-            os: ubuntu-latest
-            ghc: "8.4.4"
-            cabal: latest
-            stack: latest
-          - resolver: "lts-11.22"
-            os: ubuntu-latest
-            ghc: "8.2.2"
-            cabal: latest
-            stack: latest
-          - resolver: "lts-9.21"
-            os: ubuntu-latest
-            ghc: "8.0.2"
             cabal: latest
             stack: latest
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,13 +8,71 @@ on:
 jobs:
   build:
     name: CI
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        resolver:
+          [
+            "lts-20.20",
+            "lts-19.33",
+            "lts-18.28",
+            "lts-16.31",
+            "lts-14.27",
+            "lts-12.26",
+            "lts-11.22",
+            "lts-9.21",
+          ]
+        include:
+          - resolver: "lts-20.20"
+            os: ubuntu-latest
+            ghc: "9.2.7"
+            cabal: latest
+            stack: latest
+          - resolver: "lts-19.33"
+            os: ubuntu-latest
+            ghc: "9.0.2"
+            cabal: latest
+            stack: latest
+          - resolver: "lts-18.28"
+            os: ubuntu-latest
+            ghc: "8.10.7"
+            cabal: latest
+            stack: latest
+          - resolver: "lts-16.31"
+            os: ubuntu-latest
+            ghc: "8.8.4"
+            cabal: latest
+            stack: latest
+          - resolver: "lts-14.27"
+            os: ubuntu-latest
+            ghc: "8.6.5"
+            cabal: latest
+            stack: latest
+          - resolver: "lts-12.26"
+            os: ubuntu-latest
+            ghc: "8.4.4"
+            cabal: latest
+            stack: latest
+          - resolver: "lts-11.22"
+            os: ubuntu-latest
+            ghc: "8.2.2"
+            cabal: latest
+            stack: latest
+          - resolver: "lts-9.21"
+            os: ubuntu-latest
+            ghc: "8.0.2"
+            cabal: latest
+            stack: latest
+
     steps:
       - name: Setup GHC
         uses: haskell/actions/setup@v2
         with:
-          ghc-version: "9.2.7"
+          ghc-version: ${{ matrix.ghc }}
           enable-stack: true
+          stack-version: ${{ matrix.stack }}
+          cabal-version: ${{ matrix.cabal }}
 
       - name: Clone project
         uses: actions/checkout@v3
@@ -23,9 +81,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-${{ hashFiles('stack.yaml') }}
+          key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles('stack.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-
+            ${{ runner.os }}-${{ matrix.resolver }}-
 
+      # This entirely avoids the caching of a GHC version.
       - name: Build and run tests
-        run: "stack test --fast --no-terminal --system-ghc"
+        run: "stack test --fast --no-terminal --resolver=${{ matrix.resolver }} --system-ghc"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.0.1 (2023-05-08)
+
+#### Fixed
+
+- Restored the ability to compile with GHC versions earlier than 9.
+
 ## 6.0.0 (2023-04-29)
 
 A number of type changes have been made to improve parsing and comparison logic.

--- a/Data/Versions.hs
+++ b/Data/Versions.hs
@@ -148,7 +148,7 @@ mFromV :: Version -> Mess
 mFromV (Version me (Chunks v) r _) = case me of
   Nothing -> f
   Just e  ->
-    let cs = NEL.singleton . MDigit e $ showt e
+    let cs = (:| []) . MDigit e $ showt e
     in Mess cs $ Just (VColon, f)
   where
     f :: Mess

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-20.18
+resolver: lts-20.20

--- a/versions.cabal
+++ b/versions.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               versions
-version:            6.0.0
+version:            6.0.1
 synopsis:           Types and parsers for software version numbers.
 description:
   A library for parsing and comparing software version numbers. We like to give


### PR DESCRIPTION
This PR restores the ability to build this on GHC 8.10 and below, and also improves the CI config to prove the fix.