### PR TITLE
Fix partial pvp parser crashing

### DIFF
--- a/Data/Versions.hs
+++ b/Data/Versions.hs
@@ -904,7 +904,7 @@ pvp = parse (pvp' <* eof) "PVP"
 
 -- | Internal megaparsec parser of `pvp`.
 pvp' :: Parsec Void Text PVP
-pvp' = L.lexeme space (PVP . NEL.fromList <$> L.decimal `sepBy` char '.')
+pvp' = L.lexeme space (fmap PVP $ (maybe (fail "No decimals in pvp'") pure) . NEL.nonEmpty =<< (L.decimal `sepBy` char '.'))
 
 -- | Parse a (General) `Version`, as defined above.
 version :: Text -> Either ParsingError Version

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -31,6 +31,9 @@ goodVers = [ "1", "1.2", "1.0rc0", "1.0rc1", "1.1rc1", "1.58.0-3",  "44.0.2403.1
 badVers :: [T.Text]
 badVers = ["", "1.2 "]
 
+badPVP :: [T.Text]
+badPVP = ["", "clc237", "abc"]
+
 messes :: [T.Text]
 messes = [ "10.2+0.93+1-1", "003.03-3", "002.000-7", "20.26.1_0-2", "1.6.0a+2014+m872b87e73dfb-1"
          , "1.3.00.16851-1", "5.2.458699.0906-1", "12.0.0-3ubuntu1~20.04.5" ]
@@ -96,6 +99,8 @@ suite = testGroup "Tests"
     , testGroup "(Haskell) PVP"
       [ testGroup "Good PVPs" $
         map (\s -> testCase (T.unpack s) $ isomorphPVP s) cabalOrd
+      , testGroup "Bad PVP" $
+        map (\s -> testCase (T.unpack s) $ assertBool "A bad PVP parsed" $ isLeft $ pvp s) badPVP
       , testGroup "Comparisons" $
         zipWith (\a b -> testCase (T.unpack $ a <> " < " <> b) $ comp pvp a b) cabalOrd (tail cabalOrd)
       ]


### PR DESCRIPTION
If there are no decimal sections, `NE.fromList` will fail, which is a partial function.

This causes ghcup to crash: https://github.com/haskell/ghcup-hs/issues/983