### PR TITLE
Support for GHC 9.12

### DIFF
--- a/versions.cabal
+++ b/versions.cabal
@@ -40,7 +40,7 @@ common commons
     -Wincomplete-uni-patterns
 
   build-depends:
-    , base        >=4.10 && <4.21
+    , base        >=4.10 && <4.22
     , megaparsec  >=7
     , text        ^>=1.2 || >= 2.0 && < 2.2
     , template-haskell >= 2.15


### PR DESCRIPTION
In addition to relaxing the upper bound of the `base` dependency I changed the type of some test values from a list to `NonEmpty` in order to get rid of `x-partial` warnings.